### PR TITLE
Iteration 3: system prompt + context builder

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -1,0 +1,25 @@
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
+import { platform, arch } from "os";
+
+function identity(): string {
+  return "You are a helpful assistant. Be concise. Think step by step when using tools.";
+}
+
+function dynamicContext(): string {
+  const now = new Date().toISOString();
+  const cwd = process.cwd();
+  const os = `${platform()} ${arch()}`;
+  return `Current time: ${now}\nWorking directory: ${cwd}\nOS: ${os}`;
+}
+
+export function buildSystemPrompt(): string {
+  return [identity(), dynamicContext()].join("\n\n");
+}
+
+// TODO: history will be populated by session persistence (iteration 4)
+export function buildMessages(
+  history: MessageParam[],
+  userMessage: string,
+): MessageParam[] {
+  return [...history, { role: "user" as const, content: userMessage }];
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,6 +2,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { chat } from "../provider.js";
 import { getDefinitions, execute } from "../tools/registry.js";
+import { buildSystemPrompt, buildMessages } from "./context.js";
 
 const MAX_ITERATIONS = 20;
 
@@ -21,11 +22,12 @@ export async function runAgentLoop(
   userMessage: string,
 ): Promise<AgentResult> {
   const tools = getDefinitions();
-  const messages: MessageParam[] = [{ role: "user", content: userMessage }];
+  const system = buildSystemPrompt();
+  const messages: MessageParam[] = buildMessages([], userMessage);
   const usage = { input: 0, output: 0 };
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
-    const response = await chat(messages, tools);
+    const response = await chat(messages, tools, system);
     usage.input += response.usage.input_tokens;
     usage.output += response.usage.output_tokens;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,10 +17,12 @@ export function init(
 export async function chat(
   messages: MessageParam[],
   tools?: Anthropic.Messages.Tool[],
+  system?: string,
 ): Promise<Anthropic.Messages.Message> {
   return client.messages.create({
     model,
     max_tokens: maxTokens,
+    ...(system ? { system } : {}),
     messages,
     ...(tools?.length ? { tools } : {}),
   });


### PR DESCRIPTION
## Summary
- New `src/agent/context.ts` — composable context module with identity prompt and dynamic runtime info (time, cwd, OS)
- `buildMessages()` assembles message history + user message (ready for session persistence in iter 4)
- `provider.chat()` now accepts optional `system` param
- Agent loop wired to use both

## Verification
```bash
npx tsx src/index.ts "what time is it?"       # knows current time
npx tsx src/index.ts "what directory are you in?"  # knows cwd
npx tsx src/index.ts "who are you?"           # reflects identity
```

Closes #3