### PR TITLE
iteration 4: session persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 bot.config.ts
+.sandgarden-bot/

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -16,7 +16,6 @@ export function buildSystemPrompt(): string {
   return [identity(), dynamicContext()].join("\n\n");
 }
 
-// TODO: history will be populated by session persistence (iteration 4)
 export function buildMessages(
   history: MessageParam[],
   userMessage: string,

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -3,8 +3,10 @@ import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { chat } from "../provider.js";
 import { getDefinitions, execute } from "../tools/registry.js";
 import { buildSystemPrompt, buildMessages } from "./context.js";
+import { getHistory, appendToSession } from "../session/manager.js";
 
 const MAX_ITERATIONS = 20;
+const MAX_HISTORY = 50;
 
 function extractText(content: Anthropic.Messages.ContentBlock[]): string {
   return content
@@ -20,11 +22,16 @@ export type AgentResult = {
 
 export async function runAgentLoop(
   userMessage: string,
+  sessionId?: string,
 ): Promise<AgentResult> {
   const tools = getDefinitions();
   const system = buildSystemPrompt();
-  const messages: MessageParam[] = buildMessages([], userMessage);
+  const history = sessionId ? getHistory(sessionId, MAX_HISTORY) : [];
+  const messages: MessageParam[] = buildMessages(history, userMessage);
   const usage = { input: 0, output: 0 };
+
+  // Buffer new messages; flush once at the end for crash safety
+  const newMessages: MessageParam[] = [{ role: "user", content: userMessage }];
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     const response = await chat(messages, tools, system);
@@ -32,12 +39,15 @@ export async function runAgentLoop(
     usage.output += response.usage.output_tokens;
 
     if (response.stop_reason === "end_turn") {
+      newMessages.push({ role: "assistant", content: response.content });
+      if (sessionId) appendToSession(sessionId, newMessages);
       return { content: extractText(response.content), usage };
     }
 
     if (response.stop_reason === "tool_use") {
-      // Push the full assistant message
-      messages.push({ role: "assistant", content: response.content });
+      const assistantMsg: MessageParam = { role: "assistant", content: response.content };
+      messages.push(assistantMsg);
+      newMessages.push(assistantMsg);
 
       // Execute each tool call and build tool_result blocks
       const toolUseBlocks = response.content.filter(
@@ -58,15 +68,20 @@ export async function runAgentLoop(
         });
       }
 
-      messages.push({ role: "user", content: results });
+      const toolResultMsg: MessageParam = { role: "user", content: results };
+      messages.push(toolResultMsg);
+      newMessages.push(toolResultMsg);
       continue;
     }
 
     // Unexpected stop_reason
+    newMessages.push({ role: "assistant", content: response.content });
+    if (sessionId) appendToSession(sessionId, newMessages);
     const text = extractText(response.content);
     return { content: text || `(stopped: ${response.stop_reason})`, usage };
   }
 
+  if (sessionId) appendToSession(sessionId, newMessages);
   return {
     content: "Error: agent loop exceeded max iterations",
     usage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ init(config.anthropicApiKey, {
 registerBuiltinTools();
 
 try {
-  const result = await runAgentLoop(message);
+  const result = await runAgentLoop(message, "cli:default");
   console.log(result.content);
   console.log(
     `\n[tokens: ${result.usage.input} in, ${result.usage.output} out]`,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,0 +1,71 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from "fs";
+import { join } from "path";
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
+
+const SESSIONS_DIR = join(process.cwd(), ".sandgarden-bot", "sessions");
+
+type SessionEntry = {
+  role: "user" | "assistant";
+  content: MessageParam["content"];
+  timestamp: string;
+};
+
+function sessionPath(sessionId: string): string {
+  const safe = sessionId.replace(/:/g, "_");
+  return join(SESSIONS_DIR, `${safe}.jsonl`);
+}
+
+export function load(sessionId: string): MessageParam[] {
+  const path = sessionPath(sessionId);
+  if (!existsSync(path)) return [];
+
+  const lines = readFileSync(path, "utf-8").split("\n").filter(Boolean);
+  return lines.reduce<MessageParam[]>((acc, line, i) => {
+    try {
+      const entry: SessionEntry = JSON.parse(line);
+      acc.push({ role: entry.role, content: entry.content });
+    } catch {
+      console.warn(`[session] skipping corrupt line ${i + 1} in ${path}`);
+    }
+    return acc;
+  }, []);
+}
+
+export function appendToSession(sessionId: string, messages: MessageParam[]): void {
+  if (!existsSync(SESSIONS_DIR)) mkdirSync(SESSIONS_DIR, { recursive: true });
+
+  const path = sessionPath(sessionId);
+  const now = new Date().toISOString();
+  const lines = messages.map((msg) => {
+    const entry: SessionEntry = {
+      role: msg.role,
+      content: msg.content,
+      timestamp: now,
+    };
+    return JSON.stringify(entry);
+  });
+
+  appendFileSync(path, lines.join("\n") + "\n");
+}
+
+function isToolResultMessage(msg: MessageParam): boolean {
+  if (msg.role !== "user" || typeof msg.content === "string") return false;
+  return Array.isArray(msg.content) &&
+    msg.content.some((b) => "type" in b && b.type === "tool_result");
+}
+
+export function getHistory(sessionId: string, max: number): MessageParam[] {
+  const all = load(sessionId);
+  if (all.length <= max) return all;
+
+  let start = all.length - max;
+
+  // Walk backward to include the full tool exchange.
+  // May return slightly more than `max` — acceptable tradeoff
+  // vs breaking the assistant/tool_result pairing contract.
+  while (start > 0 && isToolResultMessage(all[start])) {
+    start--;
+  }
+
+  return all.slice(start);
+}


### PR DESCRIPTION
## Summary
- JSONL-based session persistence so the agent retains conversation context across restarts
- New `src/session/manager.ts` with `load`, `appendToSession`, `getHistory`
- Agent loop buffers all messages during a turn, flushes with a single write at the end (crash-safe — no partial/orphaned tool_use without matching tool_result)
- `getHistory` truncates to last 50 messages with safe boundary logic — walks backward to avoid splitting tool_use/tool_result pairs
- CLI hardcoded to `"cli:default"` session; `sessionId` is optional for backward compat

## Session clearing / reset
- **No auto-clearing needed**: `getHistory` already caps what's sent to the LLM (50 msgs). Files grow slowly (few KB per conversation), not worth optimizing now.
- **Session reset**: will add a `/reset` command when wiring Telegram (iteration 5). Deletes the JSONL file — user gets fresh conversation but keeps long-term knowledge once memory system (iteration 6) is in place.

## Test plan
- [ ] `npx tsx src/index.ts "My name is Carlos"` → responds
- [ ] `npx tsx src/index.ts "What's my name?"` → remembers "Carlos"
- [ ] `.sandgarden-bot/sessions/cli_default.jsonl` exists with valid JSONL
- [ ] Tool interactions persist correctly across restarts

Fixes #4 