### PR TITLE
Iteration 5: Telegram integration via grammY

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,25 @@ cp bot.config.example.ts bot.config.ts
 Simple chat:
 
 ```bash
-npx tsx src/index.ts "Hey, can you tell me a joke?"
+npm run dev "Hey, can you tell me a joke?"
 ```
 
 With tool use:
 
 ```bash
-npx tsx src/index.ts "Can you tell me which libraries are installed in the package.json file?"
+npm run dev "Can you tell me which libraries are installed in the package.json file?"
+```
+
+Session persistence (the CLI reuses the same session across calls)
+
+```bash
+npm run dev "My name is Alice"
+npm run dev "What's my name?"
 ```
 
 ## Tools
 
-The agent can call tools in a loop — it decides when to use them, executes locally, and feeds results back until done.
+The agent can call tools in a loop, it decides when to use them, executes locally, and feeds results back until done.
 
 Built-in tools:
 
@@ -40,3 +47,52 @@ Built-in tools:
 
 1. Create `src/tools/your_tool.ts` implementing the `Tool` type (name, description, JSON Schema params, execute fn)
 2. Register it in `registerBuiltinTools()` in `src/tools/registry.ts`
+
+## Sessions
+
+Conversations are persisted as JSONL files in `.sandgarden-bot/sessions/`. Each message (user or assistant) is one JSON line. The agent loads the last 50 (MAX_HISTORY) messages as history for context continuity.
+
+Session IDs:
+
+- CLI: `cli:default`
+- Telegram: `telegram:<chat_id>` (automatic per user)
+
+## Telegram
+
+Run the bot as a Telegram DM assistant using long-polling (no server needed).
+
+### Configuration
+
+Add to `bot.config.ts`:
+
+```ts
+telegramBotToken: "123456:ABC-DEF...",
+allowedChatIds: [123456789],  // your Telegram user ID
+```
+
+### Run
+
+```bash
+npm run telegram
+```
+
+The bot responds to private text messages from whitelisted chat IDs.
+
+**commands**
+/start: just prints a welcome message
+/new: start a new conversation (clears the current session)
+
+<details>
+<summary>How to set up a Telegram bot</summary>
+
+1. Message [@BotFather](https://t.me/BotFather) on Telegram
+2. Send `/newbot`, follow the prompts to pick a name and username
+3. Copy the bot token into `telegramBotToken` in your config
+
+**Getting your chat ID:**
+
+1. Message [@userinfobot](https://t.me/userinfobot) on Telegram
+2. It replies with your user/chat ID
+3. Add that number to `allowedChatIds`
+
+</details>

--- a/bot.config.example.ts
+++ b/bot.config.example.ts
@@ -4,6 +4,10 @@ const config: BotConfig = {
   anthropicApiKey: "your-api-key-here",
   model: "claude-sonnet-4-20250514",
   maxTokens: 4096,
+
+  // Telegram (optional — only needed for `npm run telegram`)
+  // telegramBotToken: "123456:ABC-DEF...",
+  // allowedChatIds: [123456789],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0"
+        "@anthropic-ai/sdk": "^0.73.0",
+        "grammy": "^1.39.3"
       },
       "devDependencies": {
         "@types/node": "^25.2.1",
@@ -488,6 +489,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grammyjs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.2.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
@@ -496,6 +503,35 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/esbuild": {
@@ -540,6 +576,15 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -568,6 +613,21 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/grammy": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.39.3.tgz",
+      "integrity": "sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.23.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -581,6 +641,32 @@
         "node": ">=16"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -590,6 +676,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -637,6 +729,22 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "telegram": "tsx src/telegram.ts"
   },
   "repository": {
     "type": "git",
@@ -11,7 +12,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.73.0"
+    "@anthropic-ai/sdk": "^0.73.0",
+    "grammy": "^1.39.3"
   },
   "devDependencies": {
     "@types/node": "^25.2.1",

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -1,15 +1,18 @@
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
-import { platform, arch } from "os";
 
 function identity(): string {
-  return "You are a helpful assistant. Be concise. Think step by step when using tools.";
+  return [
+    "You are a helpful, general-purpose AI assistant.",
+    "Be concise. Think step by step when using tools.",
+    "You can help with questions, writing, analysis, coding, math, and anything else the user needs.",
+    "Do not assume what the user wants help with, just respond to what they ask.",
+  ].join(" ");
 }
 
 function dynamicContext(): string {
   const now = new Date().toISOString();
   const cwd = process.cwd();
-  const os = `${platform()} ${arch()}`;
-  return `Current time: ${now}\nWorking directory: ${cwd}\nOS: ${os}`;
+  return `Current time: ${now}\nWorking directory: ${cwd}`;
 }
 
 export function buildSystemPrompt(): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ export type BotConfig = {
   anthropicApiKey: string;
   model?: string;
   maxTokens?: number;
+  telegramBotToken?: string;
+  allowedChatIds?: number[];
 };
 
 const DEFAULTS = {
@@ -9,7 +11,10 @@ const DEFAULTS = {
   maxTokens: 4096,
 } as const;
 
-export async function loadConfig(): Promise<Required<BotConfig>> {
+export type ResolvedConfig = Required<Pick<BotConfig, "anthropicApiKey" | "model" | "maxTokens">> &
+  Pick<BotConfig, "telegramBotToken" | "allowedChatIds">;
+
+export async function loadConfig(): Promise<ResolvedConfig> {
   let mod: { default: BotConfig };
 
   const configPath = new URL("../bot.config.js", import.meta.url).href;
@@ -33,5 +38,7 @@ export async function loadConfig(): Promise<Required<BotConfig>> {
     anthropicApiKey: raw.anthropicApiKey,
     model: raw.model ?? DEFAULTS.model,
     maxTokens: raw.maxTokens ?? DEFAULTS.maxTokens,
+    telegramBotToken: raw.telegramBotToken,
+    allowedChatIds: raw.allowedChatIds,
   };
 }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, appendFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, appendFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 
@@ -46,6 +46,13 @@ export function appendToSession(sessionId: string, messages: MessageParam[]): vo
   });
 
   appendFileSync(path, lines.join("\n") + "\n");
+}
+
+export function clearSession(sessionId: string): boolean {
+  const path = sessionPath(sessionId);
+  if (!existsSync(path)) return false;
+  unlinkSync(path);
+  return true;
 }
 
 function isToolResultMessage(msg: MessageParam): boolean {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,99 @@
+import { Bot } from "grammy";
+import { loadConfig } from "./config.js";
+import { init } from "./provider.js";
+import { registerBuiltinTools } from "./tools/registry.js";
+import { runAgentLoop } from "./agent/loop.js";
+import { clearSession } from "./session/manager.js";
+
+const TELEGRAM_MAX_LENGTH = 4096;
+
+function splitMessage(text: string): string[] {
+  if (text.length <= TELEGRAM_MAX_LENGTH) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= TELEGRAM_MAX_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to split at last newline before limit
+    const slice = remaining.slice(0, TELEGRAM_MAX_LENGTH);
+    const lastNewline = slice.lastIndexOf("\n");
+    const splitAt = lastNewline > 0 ? lastNewline : TELEGRAM_MAX_LENGTH;
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^\n/, "");
+  }
+
+  return chunks;
+}
+
+const config = await loadConfig();
+
+if (!config.telegramBotToken) {
+  console.error("Set telegramBotToken in bot.config.ts to use Telegram mode.");
+  process.exit(1);
+}
+
+init(config.anthropicApiKey, {
+  model: config.model,
+  maxTokens: config.maxTokens,
+});
+
+registerBuiltinTools();
+
+const bot = new Bot(config.telegramBotToken);
+
+function isAllowed(chatId: number, chatType: string): boolean {
+  if (chatType !== "private") return false;
+  if (config.allowedChatIds && !config.allowedChatIds.includes(chatId)) return false;
+  return true;
+}
+
+bot.command("start", async (ctx) => {
+  if (!isAllowed(ctx.chat.id, ctx.chat.type)) return;
+  await ctx.reply("Hey! I'm your AI assistant. Send me any message to chat.\n\nUse /new to start a fresh conversation.");
+});
+
+bot.command("new", async (ctx) => {
+  if (!isAllowed(ctx.chat.id, ctx.chat.type)) return;
+  clearSession(`telegram:${ctx.chat.id}`);
+  await ctx.reply("Session cleared. Starting fresh!");
+});
+
+bot.on("message:text", async (ctx) => {
+  if (!isAllowed(ctx.chat.id, ctx.chat.type)) return;
+
+  // Skip bot commands — handled above
+  if (ctx.message.text.startsWith("/")) return;
+
+  const sessionId = `telegram:${ctx.chat.id}`;
+
+  // Show typing while processing
+  const typingInterval = setInterval(() => {
+    ctx.replyWithChatAction("typing").catch(() => {});
+  }, 4000);
+
+  // Send initial typing action immediately
+  await ctx.replyWithChatAction("typing").catch(() => {});
+
+  try {
+    const result = await runAgentLoop(ctx.message.text, sessionId);
+
+    const chunks = splitMessage(result.content);
+    for (const chunk of chunks) {
+      await ctx.reply(chunk);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await ctx.reply(`Error: ${msg}`);
+  } finally {
+    clearInterval(typingInterval);
+  }
+});
+
+bot.start();
+console.log("Telegram bot started (long-polling)");


### PR DESCRIPTION
## Summary

Adds Telegram as a second frontend for the bot using grammY long-polling. Same agent loop, tools, and session system as CLI — just a different transport.

- New `src/telegram.ts` entry point (`npm run telegram`)
- `/start` greeting, `/new` to clear session
- `allowedChatIds` whitelist, private-chat-only
- Typing indicator while processing, message splitting at 4096 chars
- `clearSession()` added to session manager
- System prompt tweaked to be general-purpose (no project assumptions)
- Config: `telegramBotToken` + `allowedChatIds` optional fields

## How to test

1. Set `telegramBotToken` and `allowedChatIds` in `bot.config.ts`
2. `npm run telegram` — send a DM to the bot
3. Verify `/new` clears session (bot forgets prior context)
4. Verify unauthorized chat IDs are ignored
5. `npm run dev "hello"` — CLI still works

## Things to watch

- `ResolvedConfig` type change in `src/config.ts` — telegram fields stay optional while core fields become required
- Commands (`/start`, `/new`) skip the agent loop via `/` prefix check in the message handler

<details>
<summary>Detailed changes</summary>

- **package.json**: added `grammy` dependency + `"telegram"` npm script
- **src/config.ts**: `BotConfig` gets `telegramBotToken?` and `allowedChatIds?`; new `ResolvedConfig` type replaces `Required<BotConfig>`
- **bot.config.example.ts**: commented-out telegram fields
- **src/telegram.ts**: grammY bot with auth guard, typing interval, message splitting, `/start` + `/new` commands
- **src/session/manager.ts**: `clearSession()` deletes JSONL file
- **src/agent/context.ts**: general-purpose identity, dropped OS from dynamic context
- **README.md**: added Sessions section, Telegram section with BotFather setup guide

</details>

Closes #8