### PR TITLE
restructure session storage to per-session-id folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ Built-in tools:
 
 ## Sessions
 
-Conversations are persisted as JSONL files in `.sandgarden-bot/sessions/`. Each message (user or assistant) is one JSON line. The agent loads the last 50 (MAX_HISTORY) messages as history for context continuity.
+Each session gets its own folder under `.sandgarden-bot/sessions/<session_id>/`:
 
-Every message is also appended to a daily archive at `.sandgarden-bot/sessions/daily/YYYY-MM-DD.jsonl` — a chronological log across all sessions.
+- `current.jsonl` — active conversation (JSONL, one message per line)
+- `daily/YYYY-MM-DD.jsonl` — daily archive (append-only log)
+
+The agent loads the last 50 (MAX_HISTORY) messages from `current.jsonl` as history. `/new` in Telegram clears `current.jsonl` but preserves daily logs.
 
 Session IDs:
 
-- CLI: `cli:default`
-- Telegram: `telegram:<chat_id>` (automatic per user)
+- CLI: `cli_default`
+- Telegram: `telegram_<chat_id>` (automatic per user)
 
 ## Memory
 


### PR DESCRIPTION
## Summary

- Each session now gets its own folder (`sessions/<session_id>/`) with `current.jsonl` and `daily/` subfolder
- Previously all sessions were flat files in `sessions/` with a shared `daily/` dir
- `clearSession` deletes only `current.jsonl`, daily logs survive

## How to test

1. `npx tsx src/index.ts "hello"` → check `sessions/cli_default/current.jsonl` and `sessions/cli_default/daily/` exist
2. Telegram: send a message → check `sessions/telegram_<id>/current.jsonl` + daily created
3. `/new` in Telegram → `current.jsonl` deleted, daily logs preserved